### PR TITLE
Updating the ngs-petsc interface w.r.t. memory usage

### DIFF
--- a/src/petsc_ksp.cpp
+++ b/src/petsc_ksp.cpp
@@ -88,6 +88,12 @@ namespace ngs_petsc_interface
 	{ /* KSPDestroy(&ksp); */ }
     }
 
+  void PETScKSP :: UpdateMatrix()
+  {
+    petsc_mat->UpdateValues();
+    // Set System-Mat, and mat to build the PC from
+    KSPSetOperators(GetKSP(), petsc_mat->GetPETScMat(), petsc_mat->GetPETScMat());
+  }
 
   void PETScKSP :: SetPC (shared_ptr<PETScBasePrecond> apc)
   {
@@ -106,6 +112,10 @@ namespace ngs_petsc_interface
     petsc_sol = GetMatrix()->GetColMap()->CreatePETScVector();
   }
 
+  void PETScKSP :: SetInitialSolution(const ngs::BaseVector & sol)
+  {
+    GetMatrix()->GetColMap()->NGs2PETSc(const_cast<ngs::BaseVector&>(sol), petsc_sol);
+  }
 
   void PETScKSP :: Mult (const ngs::BaseVector & x, ngs::BaseVector & y) const
   {
@@ -194,6 +204,8 @@ namespace ngs_petsc_interface {
 	  aksp->SetPC(apc);
 	})
       .def("Finalize", [](shared_ptr<PETScKSP> & aksp) { aksp->Finalize(); })
+      .def("UpdateMatrix", [](shared_ptr<PETScKSP> & aksp) { aksp->UpdateMatrix(); })
+      .def("SetInitialSolution", [](shared_ptr<PETScKSP> & aksp, shared_ptr<ngs::BaseVector> sol) { aksp->SetInitialSolution(*sol); })
       .def_property_readonly("results",
 			     [] (PETScKSP & aksp) -> py::dict {
 			       KSP ksp = aksp.GetKSP();

--- a/src/petsc_ksp.hpp
+++ b/src/petsc_ksp.hpp
@@ -21,6 +21,8 @@ namespace ngs_petsc_interface
     ~PETScKSP ();
 
     void SetPC (shared_ptr<PETScBasePrecond> apc);
+    void UpdateMatrix ();
+    void SetInitialSolution(const ngs::BaseVector & sol);
 
     void Finalize ();
 

--- a/src/petsc_linalg.cpp
+++ b/src/petsc_linalg.cpp
@@ -966,6 +966,7 @@ IS_BAIJ .. sub-assembled diagonal blocks, blocks in sparse block matrix format (
 	     }), py::arg("ngs_mat"), py::arg("freedofs") = nullptr, py::arg("row_freedofs") = nullptr, py::arg("col_freedofs") = nullptr,
 	    py::arg("format") = py::none());
 
+    pcm.def("UpdateValues", [](shared_ptr<PETScMatrix> & mat) { return mat->UpdateValues(); });
     pcm.def("dump", [](shared_ptr<PETScMatrix> mat, string fn) {
 	cout << "dump mat to >>" << fn << "<<" << endl;
 	auto pds = mat->GetRowMap()->GetParallelDofs();

--- a/src/petsc_pc.hpp
+++ b/src/petsc_pc.hpp
@@ -83,6 +83,11 @@ namespace ngs_petsc_interface
     virtual int VWidth () const override { return GetAMat()->GetNGsMat()->VWidth(); }
 
 
+    virtual const BaseMatrix & GetMatrix() const override
+    {
+      return *this;
+    }
+
     virtual const BaseMatrix & GetAMatrix () const override { return *GetAMat()->GetNGsMat(); }
     virtual void InitLevel (shared_ptr<ngs::BitArray> freedofs = nullptr) override;
     virtual void FinalizeLevel (const ngs::BaseMatrix * mat = nullptr) override;


### PR DESCRIPTION
I would like to suggest small changes to the ngs-petsc interface.

1. To use a non-zero initial guess in PETSc, a function to set the initial solution guess from an NGSolve base vector was introduced.
2. When parameter sweeps are conducted or essentially multiple solutions with changing bilinear forms are computed, the current interface leads to incremental memory usage because every time a new KSP object is created. Thus, the matrix is stored for each solution and the memory is not freed or overwritten but new memory is allocated. This is prevented by updating the matrix in the KSP object.
3. In the complex interface example (`scattering.py`) a distributed mesh should be used.
4. In the NGSolve dev version, the preconditioner interface has changed (ngsolve/ngsolve@1662352589ccd90491cadae73964ff44cec0b16f). I am not sure if my solution is good, but without changing the code, ngs-petsc did not compile any more.